### PR TITLE
feat: Add a filter pattern option to filter out sent events by their message using regexp

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -26,6 +26,11 @@ class Config
     private $environment;
 
     /**
+     * @var string
+     */
+    private $errorMessageFilterPattern;
+
+    /**
      * @var bool
      */
     private $enabled;
@@ -95,6 +100,21 @@ class Config
     }
 
     /**
+     * @return string
+     */
+    public function getErrorMessageFilterPattern()
+    {
+        if ($this->errorMessageFilterPattern === null) {
+            $this->errorMessageFilterPattern = $this->scopeConfig->getValue(
+                'sentry/general/error_message_filter_pattern',
+                \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            );
+        }
+
+        return $this->errorMessageFilterPattern;
+    }
+
+    /**
      * @return bool
      */
     public function isEnabled(): bool
@@ -118,6 +138,20 @@ class Config
             \Sentry\init([
                 'dsn' => $this->getConnection(),
                 'environment' => $this->getEnvironment() ?? null,
+                'before_send' => function (\Sentry\Event $event, ?\Sentry\EventHint $hint): ?\Sentry\Event {
+                    $pattern = $this->getErrorMessageFilterPattern();
+                    $message = $event->getMessage();
+                    try {
+                        if ($pattern && $message && preg_match($pattern, $message)) {
+                            return null;
+                        }
+                    } catch (\Throwable $th) {
+                        // In case $pattern is invalid, preg_match will throw an exception
+                        // Let's silently ignore that then, and pass through the event.
+                        return $event;
+                    }
+                    return $event;
+                },
             ]);
             $this->hub = \Sentry\SentrySdk::getCurrentHub();
         }

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -138,7 +138,7 @@ class Config
             \Sentry\init([
                 'dsn' => $this->getConnection(),
                 'environment' => $this->getEnvironment() ?? null,
-                'before_send' => function (\Sentry\Event $event, ?\Sentry\EventHint $hint): ?\Sentry\Event {
+                'before_send' => function (\Sentry\Event $event): ?\Sentry\Event {
                     $pattern = $this->getErrorMessageFilterPattern();
                     $message = $event->getMessage();
                     try {

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -24,7 +24,11 @@
                 <field id="environment" translate="label comment" type="text" sortOrder="130" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Environment</label>
                 </field>
-<!--                <field id="customer_data" translate="label" type="select" sortOrder="130" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="error_message_filter_pattern" translate="label comment" type="text" sortOrder="130" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>Error Message filter pattern</label>
+                    <comment>RegExp pattern that will be passed to PHP preg_match function in order to filter out errors that shouldn't be sent to Sentry.</comment>
+                </field>
+                <!--                <field id="customer_data" translate="label" type="select" sortOrder="130" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Collect Customer Data</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>-->


### PR DESCRIPTION
It adds an option to admin UI, in which you can define a regexp that will be used by a `preg_match` function to filter out events that shouldn't be sent to Sentry. Useful if you have some exceptions that you're okay to ignore, and you don't want them to count toward the Sentry data quota limit.

![image](https://user-images.githubusercontent.com/1862580/133752368-3e4012ed-ec41-4b30-819b-e538902038c1.png)
